### PR TITLE
Test for `grep` exit codes >1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ node_js:
   - "node"
 addons:
   apt:
+    sources:
+      - debian-sid
     packages:
       - shellcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "node"
+sudo: required
 before_install:
-  - apt-get install shellcheck
+  - sudo apt-get install shellcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,5 @@
-language: cpp
-env:
-  - NODE_VERSION="4.2"
-  - NODE_VERSION="5.4"
-os: osx
-matrix:
-  fast_finish: true
+language: node_js
+node_js:
+  - "node"
 before_install:
-  - git clone https://github.com/creationix/nvm.git /tmp/.nvm
-  - source /tmp/.nvm/nvm.sh
-  - nvm install $NODE_VERSION
-  - nvm use --delete-prefix $NODE_VERSION
-  - brew install shellcheck
-install:
-  - npm install
-script:
-  - npm test
+  - apt-get install shellcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "node"
-sudo: required
-before_install:
-  - sudo apt-get install shellcheck
+addons:
+  apt:
+    packages:
+      - shellcheck

--- a/bin/dot-only-hunter
+++ b/bin/dot-only-hunter
@@ -53,7 +53,7 @@ main () {
     echo "Whoops! Found \`.only\` in your tests."
     exit 1
   elif [[ $rc -gt 1 ]] ; then
-    echo "Unexpected grep error. Please report this issue! :)\nhttps://github.com/dasilvacontin/dot-only-hunter/issues/new"
+    echo "\nUnexpected grep error. Please report this issue! :)\nhttps://github.com/dasilvacontin/dot-only-hunter/issues/new"
     exit 2
   else
     echo "All good!"

--- a/bin/dot-only-hunter
+++ b/bin/dot-only-hunter
@@ -53,7 +53,7 @@ main () {
     echo "Whoops! Found \`.only\` in your tests."
     exit 1
   elif [ $rc -gt 1 ]; then
-    echo "\nUnexpected grep error. Please report this issue! :)\nhttps://github.com/dasilvacontin/dot-only-hunter/issues/new"
+    printf "\nUnexpected grep error. Please report this issue! :)\nhttps://github.com/dasilvacontin/dot-only-hunter/issues/new"
     exit 2
   else
     echo "All good!"

--- a/bin/dot-only-hunter
+++ b/bin/dot-only-hunter
@@ -47,12 +47,18 @@ main () {
 
   echo "Hunting inside '$test_dir' for tests with \`.only\`..."
 
-  if grep -nR "\($prey\)\.only" "$test_dir"; then
+  grep -nR "\($prey\)\.only" "$test_dir"
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
     echo "Whoops! Found \`.only\` in your tests."
     exit 1
+  elif [[ $rc -gt 1 ]] ; then
+    echo "Unexpected grep error. Please report this issue! :)\nhttps://github.com/dasilvacontin/dot-only-hunter/issues/new"
+    exit 2
+  else
+    echo "All good!"
   fi
 
-  echo "All good!"
 }
 
 parse_cmd_args "$@"

--- a/bin/dot-only-hunter
+++ b/bin/dot-only-hunter
@@ -49,10 +49,10 @@ main () {
 
   grep -nR "\($prey\)\.only" "$test_dir"
   rc=$?
-  if [[ $rc -eq 0 ]]; then
+  if [ $rc -eq 0 ]; then
     echo "Whoops! Found \`.only\` in your tests."
     exit 1
-  elif [[ $rc -gt 1 ]] ; then
+  elif [ $rc -gt 1 ]; then
     echo "\nUnexpected grep error. Please report this issue! :)\nhttps://github.com/dasilvacontin/dot-only-hunter/issues/new"
     exit 2
   else

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:watch": "chokidar 'bin/*' --initial -c 'shellcheck bin/dot-only-hunter'",
     "start": "npm run lint:watch",
     "pretest": "npm run lint",
+    "test": "sh tests.sh",
     "prepublish": "npm run test"
   },
   "files": [

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,20 @@
+echo "# Test suite! <3"
+
+echo "\n - Exit code should be \`0\` when \`.only\` is NOT found."
+./bin/dot-only-hunter bin
+res=$?
+echo "Exit code: $res"
+if [[ $res -ne 0 ]]; then
+  exit 1
+fi
+
+echo "\n - Exit code should be \`1\` when \`.only\` is found."
+# dot-only-hunter will, at least, find this .only: `it.only(...)`
+./bin/dot-only-hunter .
+res=$?
+echo "Exit code: $res"
+if [[ $res -ne 1 ]]; then
+  exit 1
+fi
+
+echo "\nAll good! <3"


### PR DESCRIPTION
Fixes https://github.com/dasilvacontin/dot-only-hunter/issues/1

Changes to test for `grep` exit codes >1 which signal an error running `grep`. The `dot-only-hunter` script should exit with an error code if the grep command fails.

Test case:
(modify script to use argument `--asdf` on the grep command line):
```
➜  bin git:(master) ✗ ./dot-only-hunter
Hunting inside 'test' for tests with `.only`...
grep: unrecognized option `--asdf'
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
Unexpected grep error. Please report this issue! :)
https://github.com/dasilvacontin/dot-only-hunter/issues/new
```

For a "real world" case - consider grep implementations where `-R` is not supported. For that see: https://github.com/dasilvacontin/dot-only-hunter/issues/3