### PR TITLE
Add command line argument to use -r flag vs. -R for grep

### DIFF
--- a/bin/dot-only-hunter
+++ b/bin/dot-only-hunter
@@ -6,10 +6,14 @@ prey="it,describe,suite,test,st"
 # Directory for tests
 test_dir="test"
 
+# Recursion flag for grep
+grep_recursion_flag="-R"
+
 usage () {
   echo "Usage: dot-only-hunter [test_dir][options]"
   echo "  -h, --help            output usage information"
   echo "  -p, --prey <list>     additional commma-separated list of names to hunt preciding .only"
+  echo "  -r, --recurse         use -r flag instead of -R for grep"
   exit 1
 }
 
@@ -27,6 +31,9 @@ parse_cmd_args () {
         ;;
       -h|--help)
         usage
+        ;;
+      -r|--recurse)
+        grep_recursion_flag="-r"
         ;;
       *)
         test_dir="$key"
@@ -47,7 +54,7 @@ main () {
 
   echo "Hunting inside '$test_dir' for tests with \`.only\`..."
 
-  if grep -nR "\($prey\)\.only" "$test_dir"; then
+  if grep -n $grep_recursion_flag "\($prey\)\.only" "$test_dir"; then
     echo "Whoops! Found \`.only\` in your tests."
     exit 1
   fi


### PR DESCRIPTION
Fixes #3.

Users can now use `dot-only-hunter -r` to replace the default behaviour of `grep -R` with `grep -r` which is more universally supported. This is specifically implemented to support use of dot-only-hunter with Alpine Linux.

@dasilvacontin PTAL