### PR TITLE
grep recurse argument supported on alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
 language: node_js
 node_js:
   - "node"
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck

--- a/bin/dot-only-hunter
+++ b/bin/dot-only-hunter
@@ -47,7 +47,7 @@ main () {
 
   echo "Hunting inside '$test_dir' for tests with \`.only\`..."
 
-  grep -nR "\($prey\)\.only" "$test_dir"
+  grep -nr "\($prey\)\.only" "$test_dir"
   rc=$?
   if [ $rc -eq 0 ]; then
     echo "Whoops! Found \`.only\` in your tests."


### PR DESCRIPTION
Following https://github.com/dasilvacontin/dot-only-hunter/issues/3
option -r works both on alpine and macos

I updated travis configuration also